### PR TITLE
Fix reflected XSS vulns in both default themes

### DIFF
--- a/themes/gila-blog/blog-list.php
+++ b/themes/gila-blog/blog-list.php
@@ -26,7 +26,7 @@
     </div>
     <div class="gm-3 sidebar">
       <form method="get" class="inline-flex" action="<?=gila::base_url('blog')?>">
-        <input name='search' class="g-input fullwidth" value="<?=(isset($search)?$search:'')?>">
+        <input name='search' class="g-input fullwidth" value="<?=(isset($search)? htmlentities($search):'')?>">
         <button class="g-btn g-group-item" onclick='submit'>Search</button>
     </form>
       <?php view::widget_area('sidebar'); ?>

--- a/themes/gila-mag/blog-list.php
+++ b/themes/gila-mag/blog-list.php
@@ -27,7 +27,7 @@
     </div>
     <div class="gm-3 sidebar">
       <form method="get" class="inline-flex" action="<?=gila::base_url('blog')?>">
-        <input name='search' class="g-input fullwidth" value="<?=($search??'')?>">
+        <input name='search' class="g-input fullwidth" value="<?=(htmlentities($search)??'')?>">
         <button class="g-btn g-group-item" onclick='submit'>Search</button>
     </form>
       <?php view::widget_area('sidebar'); ?>


### PR DESCRIPTION
In the `blog-list.php` view of both themes included in Gila (gila-blog and gila-mag), there is a lack of HTML entity encoding, which leads to reflected cross-site scripting being possible in the search results.

An example of this can be in the console of the screenshot below when visiting the URL: `/?search=xss%22+onfocus%3D%22console.log%28document.domain%29%22+autofocus%3D%22true`

![Screenshot from 2019-10-12 21-31-06](https://user-images.githubusercontent.com/2500434/66707481-2c14f300-ed39-11e9-89c9-7adc3009c3d8.png)

This pull request fixes both instances of this by parsing the user input through `htmlentities` first.