### PR TITLE
Fix upload filter bypass leading to RCE

### DIFF
--- a/src/core/controllers/fm.php
+++ b/src/core/controllers/fm.php
@@ -88,7 +88,8 @@ class fm extends controller
   }
 
   function moveAction () {
-    if(!gForm::posted() || !rename($this->path, $_POST['newpath'])) {
+    $ext = strtolower(pathinfo($_POST['newpath'], PATHINFO_EXTENSION));
+    if($ext == 'php' || $ext == 'htaccess' || !gForm::posted() || !rename($this->path, $_POST['newpath'])) {
       ob_clean();
       die("Permission denied.");
     }


### PR DESCRIPTION
It is possible to bypass the media asset upload restrictions that are in place to prevent arbitrary PHP being executed on the server by abusing a combination of two issues.

The first is the support for uploading animated GIFs. By submitting a GIF that contains the following content we can place a GIF file that contains [currently unexecutable] PHP code in a GIF file on the server (in this case `test.gif`):

```
GIF89a; <?=`$_GET[1]`?>
```

After uploading this, the file can now be clicked and the move function can be used to move this into another directory within the application directory with a PHP extension (in this case, it is moved to `tmp/media_thumb/shell.php`):

![rename](https://user-images.githubusercontent.com/2500434/66708742-743e1080-ed4d-11e9-8ae4-2f0ec6e09969.png)

As can be seen in the below screenshot, this is now stored on the server with a valid extension:

![shell-on-server](https://user-images.githubusercontent.com/2500434/66708744-786a2e00-ed4d-11e9-9ee2-bcee843454bb.png)

At this point, the PHP file cannot be executed as the htaccess file found in `tmp/.htaccess` contains the following configuration:

```
<Files *.php>
deny from all
</Files>
```

This prevents any PHP files under `tmp/` being accessed. However, the same upload vulnerability can be abused to overwrite the htaccess file. To do this, one uploads a GIF file again but with the content:

```
# GIF89a;
```

This creates a GIF file on the server, that starts with a valid comment character, which prevents the server running into an error when parsing it during subsequent requests. The same rename bug can then be used to move this file to `tmp/.htaccess`:

![htaccess](https://user-images.githubusercontent.com/2500434/66708747-7d2ee200-ed4d-11e9-9755-fa145e819dfb.png)

After doing this, the PHP file can be accessed from the web browser, and remote code execution is gained as can be seen in the below screenshot in which `cat /etc/passwd` is executed:

![shell](https://user-images.githubusercontent.com/2500434/66708749-80c26900-ed4d-11e9-90db-c0aa2d86b0cb.png)

This pull request implements a rather simplistic means of patching this for now, by checking the extension of the specified destination path and blocking it if it is either `php` or `htaccess`. Ideally, a more robust solution should be put in place in the long term by creating a valid white list of safe extensions, but for now, this should mitigate the immediate threat.